### PR TITLE
Boost2std continue

### DIFF
--- a/utilities/message_filters/include/message_filters/signal1.h
+++ b/utilities/message_filters/include/message_filters/signal1.h
@@ -35,8 +35,6 @@
 #ifndef MESSAGE_FILTERS_SIGNAL1_H
 #define MESSAGE_FILTERS_SIGNAL1_H
 
-//#include <boost/noncopyable.hpp>
-
 #include "connection.h"
 
 #include <mutex>

--- a/utilities/message_filters/include/message_filters/signal9.h
+++ b/utilities/message_filters/include/message_filters/signal9.h
@@ -35,8 +35,6 @@
 #ifndef MESSAGE_FILTERS_SIGNAL9_H
 #define MESSAGE_FILTERS_SIGNAL9_H
 
-#include <boost/noncopyable.hpp>
-
 #include "connection.h"
 #include "null_types.h"
 

--- a/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
@@ -40,7 +40,6 @@
 #include "message_filters/null_types.h"
 #include "message_filters/signal9.h"
 
-#include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/at.hpp>

--- a/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
@@ -40,7 +40,6 @@
 #include "message_filters/null_types.h"
 #include "message_filters/signal9.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/vector.hpp>

--- a/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
@@ -40,9 +40,6 @@
 #include "message_filters/null_types.h"
 #include "message_filters/signal9.h"
 
-#include <boost/function.hpp>
-
-#include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/at.hpp>
 #include <boost/mpl/vector.hpp>

--- a/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
@@ -42,7 +42,6 @@
 
 #include <boost/function.hpp>
 
-#include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/at.hpp>

--- a/utilities/message_filters/include/message_filters/synchronizer.h
+++ b/utilities/message_filters/include/message_filters/synchronizer.h
@@ -39,7 +39,6 @@
 #include <memory>
 #include <mutex>
 
-#include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/mpl/at.hpp>
@@ -54,6 +53,7 @@
 #include <deque>
 #include <vector>
 #include <string>
+#include <type_traits>
 
 namespace message_filters
 {
@@ -370,7 +370,7 @@ struct PolicyBase
   typedef mpl::vector<M0, M1, M2, M3, M4, M5, M6, M7, M8> Messages;
   typedef Signal9<M0, M1, M2, M3, M4, M5, M6, M7, M8> Signal;
   typedef mpl::vector<const std::shared_ptr<M0>>, const std::shared_ptr<M1>, const std::shared_ptr<M2>>, const std::shared_ptr<M3>, const std::shared_ptr<M4>, const std::shared_ptr<M5>, const std::shared_ptr<M6>, const std::shared_ptr<M7>, const std::shared_ptr<M8> > Events;
-  typedef typename mpl::fold<Messages, mpl::int_<0>, mpl::if_<mpl::not_<boost::is_same<mpl::_2, NullType> >, mpl::next<mpl::std::placeholders::_1>, mpl::std::placeholders::_1> >::type RealTypeCount;
+  typedef typename mpl::fold<Messages, mpl::int_<0>, mpl::if_<mpl::not_<std::is_same<mpl::_2, NullType> >, mpl::next<mpl::std::placeholders::_1>, mpl::std::placeholders::_1> >::type RealTypeCount;
   typedef typename mpl::at_c<Events, 0>::type M0Event;
   typedef typename mpl::at_c<Events, 1>::type M1Event;
   typedef typename mpl::at_c<Events, 2>::type M2Event;

--- a/utilities/message_filters/test/test_synchronizer.cpp
+++ b/utilities/message_filters/test/test_synchronizer.cpp
@@ -37,7 +37,6 @@
 #include "tf2/time.h"
 #include <ros/init.h>
 #include "message_filters/synchronizer.h"
-#include <boost/array.hpp>
 
 using namespace message_filters;
 


### PR DESCRIPTION
Continued to replace boost with std. Seems only the biggest part boost::MPL is left.